### PR TITLE
Increase upper version bound for the text package.

### DIFF
--- a/mainland-pretty.cabal
+++ b/mainland-pretty.cabal
@@ -28,7 +28,7 @@ library
     base       >= 4    && < 5,
     containers >= 0.2  && < 0.6,
     srcloc     >= 0.2  && < 0.5,
-    text       >  0.11 && < 1.2
+    text       >  0.11 && < 1.3
 
 source-repository head
   type:     git


### PR DESCRIPTION
We are getting package version conflicts for dependencies from criterion/language-c-quote. This package seems to work as expected with text-1.2 based on our testing. 