### PR TITLE
Explicitly import what we need from Data.Monoid.

### DIFF
--- a/Text/PrettyPrint/Mainland.hs
+++ b/Text/PrettyPrint/Mainland.hs
@@ -80,7 +80,7 @@ import Data.Loc (L(..),
                  posFile,
                  posLine)
 import qualified Data.Map as Map
-import Data.Monoid
+import Data.Monoid ((<>))
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Text.Lazy.IO as TIO


### PR DESCRIPTION
This fixes a build error on GHC 7.10.1.