### PR TITLE
expose alternative

### DIFF
--- a/Text/PrettyPrint/Mainland.hs
+++ b/Text/PrettyPrint/Mainland.hs
@@ -30,7 +30,7 @@ module Text.PrettyPrint.Mainland (
     -- * Basic combinators
     empty, text, char, string, fromText, fromLazyText,
     line, nest, srcloc, column, nesting,
-    softline, softbreak, group,
+    softline, softbreak, group, alt,
 
     -- * Operators
     (<>), (<+>), (</>), (<+/>), (<//>),
@@ -168,6 +168,14 @@ softbreak = empty `Alt` line
 
 group :: Doc -> Doc
 group d = flatten d `Alt` d
+
+-- | The document @x \`alt\` y@ will be @x@ if there is room for it,
+-- otherwise @y@. @x@ and @y@ must represent the same thing, but can
+-- have different formatting.
+--
+-- prop> softline == space `alt` line
+alt :: Doc -> Doc -> Doc
+alt = Alt
 
 flatten :: Doc -> Doc
 flatten Empty        = Empty


### PR DESCRIPTION
I've run into trouble when printing long let bindings in a compiler:

```
λ> putStrLn $ pretty 20 $ text "let" <+> text "variable" <+> equals <+> 
     text "function" <> encloseSep lparen rparen comma (map ppr [1..10])
```
gives
```
let variable = function(1,
                        2,
                        3,
                        4,
                        5,
                        6,
                        7,
                        8,
                        9,
                        10)
```

By exposing `alt` I can now do this:
```
λ> let (<???>) = \x y -> (x <+> y) `alt` (x </> (indent 2 y))
λ> putStrLn $ pretty 20 $ text "let" <+> text "variable" <+> equals <???> 
     text "function" <> encloseSep lparen rparen comma (map ppr [1..10])
```
which gives
```
let variable =
  function(1, 2, 3,
           4, 5, 6,
           7, 8, 9,
           10)
```

---

I haven't been able to see any other way of doing this, but if you have a better solution I'm all ears. _(I don't want to go with always placing the expression on the next line)_

I'm not entirely sure that I'm interpreting the invariant listed in the code correctly _(all layouts of the two arguments flatten to the same layout)_, but I haven't been able to see any major problems with exposing `alt`.