### PR TITLE
Needs GHC >= 7.4 due to usage of Data.Monoid.<>

### DIFF
--- a/mainland-pretty.cabal
+++ b/mainland-pretty.cabal
@@ -26,7 +26,7 @@ library
     Text.PrettyPrint.Mainland
 
   build-depends:
-    base       >= 4    && < 5,
+    base       >= 4.5  && < 5,
     containers >= 0.2  && < 0.6,
     srcloc     >= 0.2  && < 0.6,
     text       >  0.11 && < 1.3


### PR DESCRIPTION
I revised the latest version to exclude <= 7.4: http://hackage.haskell.org/package/mainland-pretty/revisions/
